### PR TITLE
Update PTL.R

### DIFF
--- a/R/PTL.R
+++ b/R/PTL.R
@@ -171,7 +171,7 @@ PTL <- function(full.option = FALSE,
                 sd.mass = NULL,
                 type.p = NULL,
                 type.e = NULL,
-                surv.j = 1,
+                surv.j = NULL,
                 alpha.fixed = NULL,
                 alpha.unif = FALSE,
                 min.alpha = NULL,
@@ -519,7 +519,9 @@ PTL <- function(full.option = FALSE,
   }
 
 
-
+  Add an extra line to create a vector for default value(s) of surv.j of the same length as NSp
+  #Default value for surv.j to 1 if not provided
+  if (is.null(surv.j)){ surv.j<-rep(1, NSp)}
 
 
   ## II.2. Arguments which must be specified (together) ----


### PR DESCRIPTION
Fixing the same issue of surv.j specifications as for the PEG function. Setting surv.j default values to NULL, and if not provided, then affect a vector of length NSp and of value 1.